### PR TITLE
enh(core): Add build step to CircleCI and clean test files after running babel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
           paths:
             - /home/circleci/.npm
       - run:
+          name: Build
+          command: npm run bundle
+      - run:
           name: Check Linting
           command: npm run eslint
       - run:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "eslint": "npx eslint . --ext .js,.jsx",
     "eslint:fix": "npm run eslint -- --fix",
     "prepublishOnly": "npm run bundle",
-    "bundle": "babel ./src --out-dir ./lib --copy-files",
+    "clean:testfiles": "find lib -type f -name '*.test.*' -delete",
+    "bundle": "babel ./src --out-dir ./lib --copy-files && npm run clean:testfiles",
     "start:dev": "npm run bundle -- --watch --source-maps",
     "storybook": "start-storybook -p 9001 -c .storybook -s ./dynamic/compiled-components/components",
     "test": "npx jest"


### PR DESCRIPTION
The build step was missing during the CircleCI run, so I added it.

I also noticed that test files were copied over during babel transpilation. I couldn't make that work through the --ignore flag from the babel CLI, so I added a custom step. 