### PR TITLE
fix(ui): use translatable labels as props for TableCustom and InputSearch

### DIFF
--- a/src/InputField/InputFieldSearch/index.js
+++ b/src/InputField/InputFieldSearch/index.js
@@ -1,8 +1,5 @@
-/* eslint-disable react/forbid-prop-types */
 /* eslint-disable react/jsx-no-bind */
 /* eslint-disable react/jsx-filename-extension */
-/* eslint-disable react/prop-types */
-/* eslint-disable no-dupe-keys */
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -27,7 +24,6 @@ const useStyles = () => ({
     fontFamily: 'Roboto Regular',
     fontSize: 12,
     boxShadow: 'none',
-    borderRadius: 0,
     position: 'relative',
   },
   paper: {
@@ -72,7 +68,7 @@ class InputFieldSearch extends Component {
   };
 
   render() {
-    const { classes, style, ...rest } = this.props;
+    const { classes, placeholder, style, ...rest } = this.props;
     const { searchText } = this.state;
     return (
       <Paper elevation={0} className={classes.paper}>
@@ -82,7 +78,7 @@ class InputFieldSearch extends Component {
           </IconButton>
           <InputBase
             className={classes.input}
-            placeholder="Search"
+            placeholder={placeholder}
             inputProps={{ 'aria-label': 'Search' }}
             onChange={this.onSearchInputChanged}
             value={searchText}
@@ -106,8 +102,16 @@ class InputFieldSearch extends Component {
   }
 }
 
+InputFieldSearch.defaultProps = {
+  placeholder: 'Search',
+  style: {},
+};
+
 InputFieldSearch.propTypes = {
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.shape.isRequired,
+  placeholder: PropTypes.string,
+  style: PropTypes.shape,
+  onChange: PropTypes.func.isRequired,
 };
 
 export default withStyles(useStyles)(InputFieldSearch);

--- a/src/Table/TableCustom/StyledPagination.js
+++ b/src/Table/TableCustom/StyledPagination.js
@@ -1,6 +1,3 @@
-/* eslint-disable no-unused-vars */
-
-import React, { Component } from 'react';
 import TablePagination from '@material-ui/core/TablePagination';
 import { withStyles } from '@material-ui/core/styles';
 

--- a/src/Table/TableCustom/index.js
+++ b/src/Table/TableCustom/index.js
@@ -123,6 +123,7 @@ class TableCustom extends Component {
       onPaginate,
       onDuplicate,
       onPaginationLimitChanged,
+      labelDisplayedRows,
       limit,
       checkable,
       currentPage,
@@ -364,6 +365,7 @@ class TableCustom extends Component {
             onChangePage={onPaginate}
             onChangeRowsPerPage={onPaginationLimitChanged}
             ActionsComponent={TablePaginationActions}
+            labelDisplayedRows={labelDisplayedRows}
           />
         </Paper>
       </div>
@@ -374,6 +376,7 @@ class TableCustom extends Component {
 TableCustom.defaultProps = {
   enabledColumn: '',
   onRowClick: () => {},
+  labelDisplayedRows: ({ from, to, count }) => `${from}-${to} of ${count}`,
 };
 
 const anyObject = PropTypes.objectOf(
@@ -391,6 +394,7 @@ TableCustom.propTypes = {
   onPaginate: PropTypes.func.isRequired,
   onDuplicate: PropTypes.func.isRequired,
   onPaginationLimitChanged: PropTypes.func.isRequired,
+  labelDisplayedRows: PropTypes.func,
   limit: PropTypes.number.isRequired,
   checkable: PropTypes.bool.isRequired,
   currentPage: PropTypes.number.isRequired,

--- a/src/Table/TableCustom/index.js
+++ b/src/Table/TableCustom/index.js
@@ -124,6 +124,7 @@ class TableCustom extends Component {
       onDuplicate,
       onPaginationLimitChanged,
       labelDisplayedRows,
+      labelRowsPerPage,
       limit,
       checkable,
       currentPage,
@@ -366,6 +367,7 @@ class TableCustom extends Component {
             onChangeRowsPerPage={onPaginationLimitChanged}
             ActionsComponent={TablePaginationActions}
             labelDisplayedRows={labelDisplayedRows}
+            labelRowsPerPage={labelRowsPerPage}
           />
         </Paper>
       </div>
@@ -377,6 +379,7 @@ TableCustom.defaultProps = {
   enabledColumn: '',
   onRowClick: () => {},
   labelDisplayedRows: ({ from, to, count }) => `${from}-${to} of ${count}`,
+  labelRowsPerPage: 'Rows per page',
 };
 
 const anyObject = PropTypes.objectOf(
@@ -395,6 +398,7 @@ TableCustom.propTypes = {
   onDuplicate: PropTypes.func.isRequired,
   onPaginationLimitChanged: PropTypes.func.isRequired,
   labelDisplayedRows: PropTypes.func,
+  labelRowsPerPage: PropTypes.string,
   limit: PropTypes.number.isRequired,
   checkable: PropTypes.bool.isRequired,
   currentPage: PropTypes.number.isRequired,


### PR DESCRIPTION
This allows for the use of translations