### PR TITLE
fix(menu): retrieve menu entries as link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1545,9 +1545,9 @@
       }
     },
     "@material-ui/styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.3.0.tgz",
-      "integrity": "sha512-7yOu+IOvbTVM+LfFJ0c7RZKksSpi2PmPwMhVnAKo1Ca3Nadjd950ALL6WG+R/W3C3GqakUvOqA5OLMvN/8N2jg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.3.3.tgz",
+      "integrity": "sha512-quupQ6RYXbtKBJxhLkF3RQx6LSfrfuh2lYpILvk7p9XNkfqOQq36fuNVgrJ/A+NNn03uqDFfQYIWh4CByKr4hA==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@emotion/hash": "^0.7.1",
@@ -1557,14 +1557,14 @@
         "csstype": "^2.5.2",
         "deepmerge": "^4.0.0",
         "hoist-non-react-statics": "^3.2.1",
-        "jss": "10.0.0-alpha.23",
-        "jss-plugin-camel-case": "10.0.0-alpha.23",
-        "jss-plugin-default-unit": "10.0.0-alpha.23",
-        "jss-plugin-global": "10.0.0-alpha.23",
-        "jss-plugin-nested": "10.0.0-alpha.23",
-        "jss-plugin-props-sort": "10.0.0-alpha.23",
-        "jss-plugin-rule-value-function": "10.0.0-alpha.23",
-        "jss-plugin-vendor-prefixer": "10.0.0-alpha.23",
+        "jss": "10.0.0-alpha.24",
+        "jss-plugin-camel-case": "10.0.0-alpha.24",
+        "jss-plugin-default-unit": "10.0.0-alpha.24",
+        "jss-plugin-global": "10.0.0-alpha.24",
+        "jss-plugin-nested": "10.0.0-alpha.24",
+        "jss-plugin-props-sort": "10.0.0-alpha.24",
+        "jss-plugin-rule-value-function": "10.0.0-alpha.24",
+        "jss-plugin-vendor-prefixer": "10.0.0-alpha.24",
         "prop-types": "^15.7.2",
         "warning": "^4.0.1"
       }
@@ -6132,11 +6132,11 @@
       }
     },
     "css-vendor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.5.tgz",
-      "integrity": "sha512-36w+4Cg0zqFIt5TAkaM3proB6XWh5kSGmbddRCPdrRLQiYNfHPTgaWPOlCrcuZIO0iAtrG+5wsHJZ6jj8AUULA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.6.tgz",
+      "integrity": "sha512-buv8FoZh84iMrtPHYGYll00/qSNV0gYO6E/GUCjUPTsSPj7uf/wot/QZwig+7qdFGxJ7HjOSJoclbhag09TVUQ==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
+        "@babel/runtime": "^7.5.5",
         "is-in-browser": "^1.0.2"
       }
     },
@@ -12775,9 +12775,9 @@
       }
     },
     "jss": {
-      "version": "10.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.23.tgz",
-      "integrity": "sha512-r3fg6nrNdqxhaE4s3ZkyEmpVTb2UUmSu0uhKrvfSAy+N45MmlLmhgyFFaUyJOvFJzm69XYXM2Q62VhGccV6qMA==",
+      "version": "10.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.24.tgz",
+      "integrity": "sha512-kfuSitcj7MTrDtSPLkrWcZppgZlTE3A+cqrkC+Z10WYROt0RXIWINAaK8tE2ohwkDfUlaM1YcRYvV3iT6YNFTA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "csstype": "^2.6.5",
@@ -12786,69 +12786,69 @@
       }
     },
     "jss-plugin-camel-case": {
-      "version": "10.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.23.tgz",
-      "integrity": "sha512-QaXi/t4Efx0BhwbVf6GCcpn/IDAP9cK/GJoWBoAIVM9BAj7RXBU0UifFojRbeDGDtpf5djDWCOMviydYiWYYWg==",
+      "version": "10.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.24.tgz",
+      "integrity": "sha512-cRYLbGl6oO9wdGXp3hn+xqc8pw8bjaui25dDYuEeEsRZMh5/OKl3ByYxDT3PLKgFqouy5Xo+YmLGVH8l+nnEdQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "hyphenate-style-name": "^1.0.3",
-        "jss": "10.0.0-alpha.23"
+        "jss": "10.0.0-alpha.24"
       }
     },
     "jss-plugin-default-unit": {
-      "version": "10.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0-alpha.23.tgz",
-      "integrity": "sha512-XE4CcrQMF2rI6TL+/bJUDVlmgIqOax8uCPLZxZnqUFTbH0cM9f66OhRIe51yECfAb1nAiHalZtkUv2kfycLVjQ==",
+      "version": "10.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0-alpha.24.tgz",
+      "integrity": "sha512-1E1XlJqJ/9I1lR5EO/tA75U1LIIicKvW6xZEKLxAP8NC/rUjI+yBQBTBJn61LOpua51e7fgW8me46Z+iuXiC4A==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.23"
+        "jss": "10.0.0-alpha.24"
       }
     },
     "jss-plugin-global": {
-      "version": "10.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.0-alpha.23.tgz",
-      "integrity": "sha512-uaoO4yp24dtvKiMd8fLzy2Of3rDSzA9e1y8mHw4vNDTPDSF39pYfpAxxnGnvRadsAVlZGgj4Ro+LveLz8ZUHgw==",
+      "version": "10.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.0-alpha.24.tgz",
+      "integrity": "sha512-3LoxrZloF4tvXrS5S7enV9OhtaxXsEP3BQdiE76vI/ecCmgNDZNpnPd8MG20ptn2iAOsoMGfoMX20Ea1IKl/Mg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.23"
+        "jss": "10.0.0-alpha.24"
       }
     },
     "jss-plugin-nested": {
-      "version": "10.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.0-alpha.23.tgz",
-      "integrity": "sha512-xHoBBUz9U8INvizthl0k9u79z+ObzY0HvzPy7+BKxySQzHSTLG40iRYizJo7Antq7uH8i8uI/5RgS/7dy+YVSQ==",
+      "version": "10.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.0-alpha.24.tgz",
+      "integrity": "sha512-BWU6NaRZTVSJc7N+3FeHacdkFOjCMThouoRQPCWVxeT0nmAVlVGwgYzChcI+vzncx+UaRQC0x+01FYhVQ2xAFA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.23",
+        "jss": "10.0.0-alpha.24",
         "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-props-sort": {
-      "version": "10.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0-alpha.23.tgz",
-      "integrity": "sha512-/h6epoQ/ta61e6rG3/Pq47qPlg9YX5t2rSKJBLzaASEe/KfxjVvnbJKC8tE27lG6TjwbeWpKONuJfZxjWKLnDg==",
+      "version": "10.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0-alpha.24.tgz",
+      "integrity": "sha512-TB4RpXwnGSEE58rN2RRzcWqhIaz0oAS1UBg10mk1fuLpkKyHEJWuuZXzgGih23Ivl/8LDVzTF+QRY5JagMUUGg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.23"
+        "jss": "10.0.0-alpha.24"
       }
     },
     "jss-plugin-rule-value-function": {
-      "version": "10.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0-alpha.23.tgz",
-      "integrity": "sha512-N0g7x6RzeEj+GI5303JOUTyo5x7/F+0SRJv3R0lAUSS782mZipcvpFzHlEz3q5g+0t/bhbOLT6i0RYAhN3IW7g==",
+      "version": "10.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0-alpha.24.tgz",
+      "integrity": "sha512-uFw4tf8PN48bdv4ZcDjG3OzKPIFZ4gpCC1cWO/dyexYfFIubX3bnQUbK4B0wPNe9LJU4KQo8s4F42B8B1ADTrA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.23"
+        "jss": "10.0.0-alpha.24"
       }
     },
     "jss-plugin-vendor-prefixer": {
-      "version": "10.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0-alpha.23.tgz",
-      "integrity": "sha512-WtTXR+H1tGGhmEP3kqDawxnV1tbXboxtJ93A1O9p+7OLseafIaQoPkMPKEh5a+P4jzETIqmQoJJoG5KmT/Tgsg==",
+      "version": "10.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0-alpha.24.tgz",
+      "integrity": "sha512-hffKj0kSSvZsXs6RYEylpBlEGjryMzU1lsWqC5vQAT/Xb3tDe60BbEarEOFLBGv7EfyajXkuRwlXAQocV5ejCg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "css-vendor": "^2.0.5",
-        "jss": "10.0.0-alpha.23"
+        "jss": "10.0.0-alpha.24"
       }
     },
     "jsx-ast-utils": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@emotion/styled": "^10.0.14",
     "@material-ui/core": "^4.2.1",
     "@material-ui/icons": "^4.0.1",
+    "@material-ui/styles": "^4.3.3",
     "axios": "^0.18.0",
     "classnames": "^2.2.6",
     "cli-color": "^1.4.0",

--- a/src/Logo/index.js
+++ b/src/Logo/index.js
@@ -13,7 +13,7 @@ import logo from '../../img/centreon.png';
 class Logo extends Component {
   render() {
     const { customClass, onClick } = this.props;
-    console.log(this.props.customClass);
+
     return (
       <div
         onClick={onClick}

--- a/src/Navigation/index.js
+++ b/src/Navigation/index.js
@@ -54,6 +54,15 @@ class Navigation extends Component {
     return url;
   };
 
+  activateSecondLevel = (secondLevelPage) => {
+    const { activeSecondLevel } = this.state;
+
+    this.setState({
+      activeSecondLevel:
+        activeSecondLevel === secondLevelPage ? true : secondLevelPage,
+    });
+  };
+
   getActiveTopLevelIndex = (pageId) => {
     const { navigationData } = this.props;
     let index = -1;
@@ -81,15 +90,6 @@ class Navigation extends Component {
     return imersion
       ? !isNaN(page) && String(page).substring(0, imersion) === level.page
       : !isNaN(page) && page === level.page;
-  };
-
-  activateSecondLevel = (secondLevelPage) => {
-    const { activeSecondLevel } = this.state;
-
-    this.setState({
-      activeSecondLevel:
-        activeSecondLevel === secondLevelPage ? true : secondLevelPage,
-    });
   };
 
   render() {

--- a/src/Navigation/index.js
+++ b/src/Navigation/index.js
@@ -11,6 +11,8 @@
 
 import React, { Component } from 'react';
 import classnames from 'classnames';
+import Link from '@material-ui/core/Link';
+import { Link as RouterLink } from 'react-router-dom';
 import styles from './navigation.scss';
 import BoundingBox from '../BoundingBox';
 
@@ -128,192 +130,189 @@ class Navigation extends Component {
           styles[customStyle || ''],
         )}
       >
-        {navigationData.map((firstLevel, firstLevelIndex) => (
-          <li
-            className={classnames(styles['menu-item'], {
-              [styles[`color-${firstLevel.color}`]]: true,
-              [styles[
-                firstLevel.toggled || this.areSamePage(pageId, firstLevel, 1)
-                  ? `active-${firstLevel.color}`
-                  : ''
-              ]]: true,
-              [styles[
-                firstLevel.toggled || this.areSamePage(pageId, firstLevel, 1)
-                  ? `active`
-                  : ''
-              ]]: true,
-            })}
-            key={`firstLevel-${firstLevel.page}`}
-          >
-            <span
-              className={classnames(styles['menu-item-link'])}
-              onDoubleClick={() => {
-                this.setState({
-                  hrefOfIframe: false,
-                });
-                handleDirectClick(firstLevel.page, firstLevel);
-              }}
+        {navigationData.map((firstLevel, firstLevelIndex) => {
+          const secondLevelIsActive =
+            firstLevel.toggled || this.areSamePage(pageId, firstLevel, 1);
+          return (
+            <li
+              className={classnames(styles['menu-item'], {
+                [styles[`color-${firstLevel.color}`]]: true,
+                [styles.active]: secondLevelIsActive,
+                [styles[`active-${firstLevel.color}`]]: secondLevelIsActive,
+              })}
+              key={`firstLevel-${firstLevel.page}`}
             >
               <span
-                className={classnames(styles.iconmoon, {
-                  [styles[`icon-${firstLevel.icon}`]]: true,
-                })}
+                className={classnames(styles['menu-item-link'])}
+                onDoubleClick={() => {
+                  this.setState({
+                    hrefOfIframe: false,
+                  });
+                  handleDirectClick(firstLevel.page, firstLevel);
+                }}
               >
-                <span className={classnames(styles['menu-item-name'])}>
-                  {firstLevel.label}
+                <span
+                  className={classnames(styles.iconmoon, {
+                    [styles[`icon-${firstLevel.icon}`]]: true,
+                  })}
+                >
+                  <span className={classnames(styles['menu-item-name'])}>
+                    {firstLevel.label}
+                  </span>
                 </span>
               </span>
-            </span>
-            <ul
-              className={classnames(
-                styles.collapse,
-                styles['collapsed-items'],
-                styles['list-unstyled'],
-                {
-                  [styles[`border-${firstLevel.color}`]]: true,
-                  [styles[
-                    activeIndex !== -1 &&
-                    firstLevelIndex > activeIndex &&
-                    sidebarActive &&
-                    navigationData[activeIndex].children.length >= 5
-                      ? 'towards-down'
-                      : 'towards-up'
-                  ]]: true,
-                },
-              )}
-            >
-              {firstLevel.children.map((secondLevel) => {
-                const secondLevelUrl = this.getUrlFromEntry(secondLevel);
-                return (
-                  <li
-                    className={classnames(styles['collapsed-item'], {
-                      [styles[
-                        activeSecondLevel === secondLevel.page ||
-                        (!activeSecondLevel &&
-                          this.areSamePage(pageId, secondLevel, 3))
-                          ? `active`
-                          : ''
-                      ]]: true,
-                      [styles[
-                        secondLevel.toggled ||
-                        this.areSamePage(pageId, secondLevel, 3)
-                          ? `active-${firstLevel.color}`
-                          : ''
-                      ]]: true,
-                    })}
-                    onClick={() => {
-                      if (secondLevel.groups.length < 1) {
-                        this.onNavigate(secondLevel.page, secondLevelUrl);
-                      } else if (this.areSamePage(pageId, firstLevel, 1)) {
-                        this.activateSecondLevel(secondLevel.page);
-                      }
-                    }}
-                    key={`secondLevel-${secondLevel.page}`}
-                  >
-                    <span
-                      className={classnames(
-                        styles['collapsed-item-level-link'],
-                        {
-                          [styles[`color-${firstLevel.color}`]]: true,
-                          [styles[
-                            secondLevel.groups.length < 1 ? 'img-none' : ''
-                          ]]: true,
-                        },
-                      )}
+              <ul
+                className={classnames(
+                  styles.collapse,
+                  styles['collapsed-items'],
+                  styles['list-unstyled'],
+                  {
+                    [styles[`border-${firstLevel.color}`]]: true,
+                    [styles[
+                      activeIndex !== -1 &&
+                      firstLevelIndex > activeIndex &&
+                      sidebarActive &&
+                      navigationData[activeIndex].children.length >= 5
+                        ? 'towards-down'
+                        : 'towards-up'
+                    ]]: true,
+                  },
+                )}
+              >
+                {firstLevel.children.map((secondLevel) => {
+                  const secondLevelUrl = this.getUrlFromEntry(secondLevel);
+                  return (
+                    <li
+                      className={classnames(styles['collapsed-item'], {
+                        [styles[
+                          activeSecondLevel === secondLevel.page ||
+                          (!activeSecondLevel &&
+                            this.areSamePage(pageId, secondLevel, 3))
+                            ? `active`
+                            : ''
+                        ]]: true,
+                        [styles[
+                          secondLevel.toggled ||
+                          this.areSamePage(pageId, secondLevel, 3)
+                            ? `active-${firstLevel.color}`
+                            : ''
+                        ]]: true,
+                      })}
+                      key={`secondLevel-${secondLevel.page}`}
                     >
-                      {secondLevel.label}
-                    </span>
-                    <BoundingBox active>
-                      {({ rectBox }) => {
-                        let styleFor3rdLevel = {};
-                        if (rectBox && rectBox.bottom < 1) {
-                          styleFor3rdLevel = {
-                            height: rectBox.offsetHeight + rectBox.bottom,
-                            overflowY: 'scroll',
-                          };
-                        }
-                        return (
-                          <ul
-                            className={classnames(
-                              styles['collapse-level'],
-                              styles['collapsed-level-items'],
-                              styles['first-level'],
-                              styles['list-unstyled'],
-                              styles['towards-up'],
-                            )}
-                            style={styleFor3rdLevel}
-                          >
-                            {secondLevel.groups.map((group) => (
-                              <React.Fragment
-                                key={`thirdLevelFragment-${group.label}`}
-                              >
-                                {secondLevel.groups.length > 1 ? (
-                                  <span
-                                    className={classnames(
-                                      styles['collapsed-level-title'],
-                                    )}
-                                  >
-                                    <span>{group.label}</span>
-                                  </span>
-                                ) : null}
-                                {group.children.map((thirdLevel) => {
-                                  const thirdLevelUrl = this.getUrlFromEntry(
-                                    thirdLevel,
-                                  );
-                                  return (
-                                    <li
+                      <Link
+                        className={classnames(
+                          styles['collapsed-item-level-link'],
+                          styles[`color-${firstLevel.color}`],
+                          {
+                            [styles['img-none']]: secondLevel.groups.length < 1,
+                          },
+                        )}
+                        onClick={(e) => {
+                          if (secondLevel.groups.length < 1) {
+                            this.setState({
+                              navigatedPageId: secondLevel.page,
+                              hrefOfIframe: false,
+                            });
+                          } else {
+                            // do not redirect if level 2 has children
+                            e.preventDefault();
+
+                            if (this.areSamePage(pageId, firstLevel, 1)) {
+                              this.activateSecondLevel(secondLevel.page);
+                            }
+                          }
+                        }}
+                        component={RouterLink}
+                        to={secondLevelUrl.url}
+                      >
+                        {secondLevel.label}
+                      </Link>
+                      <BoundingBox active>
+                        {({ rectBox }) => {
+                          let styleFor3rdLevel = {};
+                          if (rectBox && rectBox.bottom < 1) {
+                            styleFor3rdLevel = {
+                              height: rectBox.offsetHeight + rectBox.bottom,
+                              overflowY: 'scroll',
+                            };
+                          }
+                          return (
+                            <ul
+                              className={classnames(
+                                styles['collapse-level'],
+                                styles['collapsed-level-items'],
+                                styles['first-level'],
+                                styles['list-unstyled'],
+                                styles['towards-up'],
+                              )}
+                              style={styleFor3rdLevel}
+                            >
+                              {secondLevel.groups.map((group) => (
+                                <React.Fragment
+                                  key={`thirdLevelFragment-${group.label}`}
+                                >
+                                  {secondLevel.groups.length > 1 ? (
+                                    <span
                                       className={classnames(
-                                        styles['collapsed-level-item'],
-                                        {
-                                          [styles[
-                                            thirdLevel.toggled ||
-                                            this.areSamePage(pageId, thirdLevel)
-                                              ? `active`
-                                              : ''
-                                          ]]: true,
-                                          [styles[
-                                            thirdLevel.toggled ||
-                                            this.areSamePage(pageId, thirdLevel)
-                                              ? `active-${firstLevel.color}`
-                                              : ''
-                                          ]]: true,
-                                        },
+                                        styles['collapsed-level-title'],
                                       )}
-                                      key={`thirdLevel-${thirdLevel.page}`}
                                     >
-                                      <a
-                                        onClick={() => {
-                                          this.onNavigate(
-                                            thirdLevel.page,
-                                            thirdLevelUrl,
-                                          );
-                                        }}
+                                      <span>{group.label}</span>
+                                    </span>
+                                  ) : null}
+                                  {group.children.map((thirdLevel) => {
+                                    const thirdLevelUrl = this.getUrlFromEntry(
+                                      thirdLevel,
+                                    );
+                                    const thirdLevelIsActive =
+                                      thirdLevel.toggled ||
+                                      this.areSamePage(pageId, thirdLevel);
+                                    return (
+                                      <li
                                         className={classnames(
-                                          styles['collapsed-item-level-link'],
+                                          styles['collapsed-level-item'],
                                           {
+                                            [styles.active]: thirdLevelIsActive,
                                             [styles[
-                                              `color-${firstLevel.color}`
-                                            ]]: true,
+                                              `active-${firstLevel.color}`
+                                            ]]: thirdLevelIsActive,
                                           },
                                         )}
+                                        key={`thirdLevel-${thirdLevel.page}`}
                                       >
-                                        <span>{thirdLevel.label}</span>
-                                      </a>
-                                    </li>
-                                  );
-                                })}
-                              </React.Fragment>
-                            ))}
-                          </ul>
-                        );
-                      }}
-                    </BoundingBox>
-                  </li>
-                );
-              })}
-            </ul>
-          </li>
-        ))}
+                                        <Link
+                                          className={classnames(
+                                            styles['collapsed-item-level-link'],
+                                            styles[`color-${firstLevel.color}`],
+                                          )}
+                                          onClick={() => {
+                                            this.setState({
+                                              navigatedPageId: thirdLevel.page,
+                                              hrefOfIframe: false,
+                                            });
+                                          }}
+                                          component={RouterLink}
+                                          to={thirdLevelUrl.url}
+                                        >
+                                          {thirdLevel.label}
+                                        </Link>
+                                      </li>
+                                    );
+                                  })}
+                                </React.Fragment>
+                              ))}
+                            </ul>
+                          );
+                        }}
+                      </BoundingBox>
+                    </li>
+                  );
+                })}
+              </ul>
+            </li>
+          );
+        })}
       </ul>
     );
   }

--- a/src/Navigation/index.js
+++ b/src/Navigation/index.js
@@ -54,6 +54,20 @@ class Navigation extends Component {
     return url;
   };
 
+  getActiveTopLevelIndex = (pageId) => {
+    const { navigationData } = this.props;
+    let index = -1;
+    for (let i = 0; i < navigationData.length; i++) {
+      if (
+        !isNaN(pageId) &&
+        String(pageId).charAt(0) === navigationData[i].page
+      ) {
+        index = i;
+      }
+    }
+    return index;
+  };
+
   onNavigate = (id, url) => {
     const { onNavigate } = this.props;
     this.setState({
@@ -106,6 +120,8 @@ class Navigation extends Component {
       pageId = reactRoutes[pathname] || pathname;
     }
 
+    const activeIndex = this.getActiveTopLevelIndex(pageId);
+
     return (
       <ul
         className={classnames(
@@ -115,7 +131,7 @@ class Navigation extends Component {
           styles[sidebarActive ? 'menu-big' : 'menu-small'],
         )}
       >
-        {navigationData.map((firstLevel) => {
+        {navigationData.map((firstLevel, firstLevelIndex) => {
           const firstLevelIsActive =
             firstLevel.toggled || this.areSamePage(pageId, firstLevel, 1);
           return (
@@ -172,6 +188,14 @@ class Navigation extends Component {
                   styles['collapsed-items'],
                   styles['list-unstyled'],
                   styles[`border-${firstLevel.color}`],
+                  styles[
+                    activeIndex !== -1 &&
+                    firstLevelIndex > activeIndex &&
+                    sidebarActive &&
+                    navigationData[activeIndex].children.length >= 5
+                      ? 'towards-down'
+                      : 'towards-up'
+                  ],
                 )}
               >
                 {firstLevel.children.map((secondLevel) => {

--- a/src/Navigation/index.js
+++ b/src/Navigation/index.js
@@ -54,20 +54,6 @@ class Navigation extends Component {
     return url;
   };
 
-  getActiveTopLevelIndex = (pageId) => {
-    const { navigationData } = this.props;
-    let index = -1;
-    for (let i = 0; i < navigationData.length; i++) {
-      if (
-        !isNaN(pageId) &&
-        String(pageId).charAt(0) === navigationData[i].page
-      ) {
-        index = i;
-      }
-    }
-    return index;
-  };
-
   onNavigate = (id, url) => {
     const { onNavigate } = this.props;
     this.setState({
@@ -120,8 +106,6 @@ class Navigation extends Component {
       pageId = reactRoutes[pathname] || pathname;
     }
 
-    const activeIndex = this.getActiveTopLevelIndex(pageId);
-
     return (
       <ul
         className={classnames(
@@ -131,7 +115,7 @@ class Navigation extends Component {
           styles[sidebarActive ? 'menu-big' : 'menu-small'],
         )}
       >
-        {navigationData.map((firstLevel, firstLevelIndex) => {
+        {navigationData.map((firstLevel) => {
           const firstLevelIsActive =
             firstLevel.toggled || this.areSamePage(pageId, firstLevel, 1);
           return (
@@ -188,14 +172,6 @@ class Navigation extends Component {
                   styles['collapsed-items'],
                   styles['list-unstyled'],
                   styles[`border-${firstLevel.color}`],
-                  styles[
-                    activeIndex !== -1 &&
-                    firstLevelIndex > activeIndex &&
-                    sidebarActive &&
-                    navigationData[activeIndex].children.length >= 5
-                      ? 'towards-down'
-                      : 'towards-up'
-                  ],
                 )}
               >
                 {firstLevel.children.map((secondLevel) => {
@@ -256,7 +232,6 @@ class Navigation extends Component {
                                 styles['collapsed-level-items'],
                                 styles['first-level'],
                                 styles['list-unstyled'],
-                                styles['towards-up'],
                               )}
                               style={styleFor3rdLevel}
                             >

--- a/src/Navigation/index.js
+++ b/src/Navigation/index.js
@@ -93,12 +93,7 @@ class Navigation extends Component {
   };
 
   render() {
-    const {
-      navigationData,
-      sidebarActive,
-      location: { pathname, search },
-      reactRoutes,
-    } = this.props;
+    const { navigationData, sidebarActive, reactRoutes } = this.props;
     const {
       activeSecondLevel,
       doubleClickedLevel,
@@ -106,6 +101,7 @@ class Navigation extends Component {
       hrefOfIframe,
     } = this.state;
     let pageId = '';
+    const { pathname, search } = window.location;
 
     if (navigatedPageId && !hrefOfIframe) {
       pageId = navigatedPageId;

--- a/src/Navigation/index.js
+++ b/src/Navigation/index.js
@@ -222,15 +222,12 @@ class Navigation extends Component {
                           if (rectBox && rectBox.bottom < 1) {
                             styleFor3rdLevel = {
                               height: rectBox.offsetHeight + rectBox.bottom,
-                              overflowY: 'scroll',
                             };
                           }
                           return (
                             <ul
                               className={classnames(
-                                styles['collapse-level'],
                                 styles['collapsed-level-items'],
-                                styles['first-level'],
                                 styles['list-unstyled'],
                               )}
                               style={styleFor3rdLevel}

--- a/src/Navigation/navigation.scss
+++ b/src/Navigation/navigation.scss
@@ -25,7 +25,6 @@
     &-link {
       border-bottom: 1px solid $white-color;
       text-align: left;
-      text-decoration: none;
       display: block;
       position: relative;
       cursor: pointer;
@@ -188,7 +187,6 @@
           background-color: $turquoise-centreon-darken;
         }
       }
-     
     }
     &.color-85B446 {
       .menu-item-link {
@@ -276,7 +274,6 @@
         &-level-link {
           border-bottom: 1px solid $grey-classic;
           text-align: left;
-          text-decoration: none;
           font-size: 0.7rem;
           color: $centreon-graphit;
           font-family: $primary-font-regular;
@@ -390,7 +387,6 @@
           &-link {
             border-bottom: 1px solid #f6f6f6;
             text-align: left;
-            text-decoration: none;
             font-size: .7rem;
             color: #242f3b;
             font-family: $primary-font-regular;

--- a/src/Navigation/navigation.scss
+++ b/src/Navigation/navigation.scss
@@ -259,6 +259,14 @@
       &.border-319ED5 {
         border-left: 5px solid $lightblue-centreon-primary;
       }
+      &.towards-up {
+        top: 0;
+        bottom: auto;
+      }
+      &.towards-down {
+        top: auto;
+        bottom: 0;
+      }
     }
     .collapsed {
       &-item {

--- a/src/Navigation/navigation.scss
+++ b/src/Navigation/navigation.scss
@@ -260,13 +260,6 @@
       &.border-319ED5 {
         border-left: 5px solid $lightblue-centreon-primary;
       }
-      &.towards-up {
-        top: 0;
-      }
-      &.towards-down {
-        top: auto;
-        bottom: 0;
-      }
     }
     .collapsed {
       &-item {
@@ -365,13 +358,6 @@
           box-shadow: 3px 3px 3px 0 rgba(70,75,82,.5);
           background-color: $white-color;
           z-index: 99;
-          &.towards-up {
-            top: 0;
-          }
-          &.towards-down {
-            top: auto;
-            bottom: 0;
-          }
           &.full {
             position: fixed;
             top: 0;

--- a/src/Navigation/navigation.scss
+++ b/src/Navigation/navigation.scss
@@ -229,7 +229,6 @@
             color: $white-color;
           }
         }
-       
       }
     }
   }
@@ -358,15 +357,7 @@
           box-shadow: 3px 3px 3px 0 rgba(70,75,82,.5);
           background-color: $white-color;
           z-index: 99;
-          &.full {
-            position: fixed;
-            top: 0;
-            bottom: 0;
-            overflow-y: scroll;
-            left: 208px;
-            height: 100vh;
-            width: 150px;
-          }
+          overflow-y: auto;
         }
         &-item {
           position: relative;
@@ -494,18 +485,6 @@
             background-image: none !important;
             color: $white-color !important;
           }
-        }
-      }
-    }
-    .collapsed-level-items {
-      &.full {
-        max-height: 350px;
-      }
-    }
-    .collapse {
-      .collapsed-level-items {
-        &.full {
-          left: 328px;
         }
       }
     }

--- a/src/Sidebar/index.js
+++ b/src/Sidebar/index.js
@@ -23,13 +23,7 @@ class Sidebar extends Component {
   };
 
   render() {
-    const {
-      navigationData,
-      reactRoutes,
-      handleDirectClick,
-      externalHistory,
-      style,
-    } = this.props;
+    const { navigationData, reactRoutes, location, style } = this.props;
     const { active } = this.state;
     return (
       <nav
@@ -47,12 +41,10 @@ class Sidebar extends Component {
             <LogoMini onClick={this.toggleNavigation} />
           )}
           <Navigation
-            customStyle={active ? 'menu-big' : 'menu-small'}
             navigationData={navigationData || []}
             reactRoutes={reactRoutes || {}}
             sidebarActive={active}
-            handleDirectClick={handleDirectClick}
-            externalHistory={externalHistory}
+            location={location}
           />
           <div
             className={classnames(styles['sidebar-toggle-wrap'])}

--- a/src/Sidebar/index.js
+++ b/src/Sidebar/index.js
@@ -27,7 +27,6 @@ class Sidebar extends Component {
       navigationData,
       reactRoutes,
       handleDirectClick,
-      onNavigate,
       externalHistory,
       style,
     } = this.props;
@@ -52,7 +51,6 @@ class Sidebar extends Component {
             navigationData={navigationData || []}
             reactRoutes={reactRoutes || {}}
             sidebarActive={active}
-            onNavigate={onNavigate}
             handleDirectClick={handleDirectClick}
             externalHistory={externalHistory}
           />

--- a/src/Sidebar/index.js
+++ b/src/Sidebar/index.js
@@ -23,8 +23,9 @@ class Sidebar extends Component {
   };
 
   render() {
-    const { navigationData, reactRoutes, location, style } = this.props;
+    const { navigationData, reactRoutes, style } = this.props;
     const { active } = this.state;
+
     return (
       <nav
         className={classnames(
@@ -44,7 +45,6 @@ class Sidebar extends Component {
             navigationData={navigationData || []}
             reactRoutes={reactRoutes || {}}
             sidebarActive={active}
-            location={location}
           />
           <div
             className={classnames(styles['sidebar-toggle-wrap'])}

--- a/src/Sidebar/sidebar.scss
+++ b/src/Sidebar/sidebar.scss
@@ -1,7 +1,6 @@
 @import '../global-sass-files/variables';
 
 .sidebar {
-  height: 100vh;
   min-width: 45px;
   max-width: 45px;
   text-align: center;

--- a/src/Sidebar/sidebar.scss
+++ b/src/Sidebar/sidebar.scss
@@ -1,6 +1,7 @@
 @import '../global-sass-files/variables';
 
 .sidebar {
+  height: 100vh;
   min-width: 45px;
   max-width: 45px;
   text-align: center;


### PR DESCRIPTION
This is a first step before reworking third level position, and split components

* allow to open menu entry in new tab
* preventDefault on menu entry double click (avoid to highlight text)
* reduce number of required props
